### PR TITLE
Remove unneeded contents.walk returns

### DIFF
--- a/examples/add-team-members.ipynb
+++ b/examples/add-team-members.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os.path\n",
+    "import pandas as pd\n",
+    "\n",
+    "from ovation.session import connect"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = connect(input('Email: '))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get \"Member\" role"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "member_role = [r for r in s.get('/roles') if r.name == 'Member'][0]\n",
+    "member_role"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load teams and members"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "members_path = os.path.expanduser(input('Members: '))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "projects_path = os.path.expanduser(input('Projects: '))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "members = pd.read_csv(members_path, header=0, names=['name', 'email'])\n",
+    "members.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "projects = pd.read_csv(projects_path, header=0, names=['name', 'uuid'])\n",
+    "projects.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add memberships"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for project_id in projects.uuid:\n",
+    "    for member in members:\n",
+    "        # TODO assumes membership does not already exist\n",
+    "        membership = {\"membership\": {\"email\": member,\n",
+    "                                     \"role\": member_role}}\n",
+    "        s.post('/teams/{}'.format(project_id), data=membership)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3.0
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/test/test_contents.py
+++ b/test/test_contents.py
@@ -7,10 +7,10 @@ from unittest.mock import Mock, sentinel, patch
 from nose.tools import istest, assert_equal, set_trace
 
 @istest
-@patch('ovation.contents.get_entity_directory_path')
+@patch('ovation.contents.get_breadcrumbs')
 @patch('ovation.contents.get_head_revision')
 @patch('ovation.contents.get_contents')
-def should_walk_path(get_contents, get_head_revision, get_entity_directory_path):
+def should_walk_path(get_contents, get_head_revision, get_breadcrumbs):
 
     project_name = 'proj1'
     file_name = 'file1'
@@ -20,14 +20,13 @@ def should_walk_path(get_contents, get_head_revision, get_entity_directory_path)
                                  'folders': [{'attributes': {'name': folder_name}}]}
     get_head_revision.return_value = {'attributes': {'name': file_name }}
 
-    get_entity_directory_path.return_value = project_name + "/"
+    get_breadcrumbs.return_value = project_name + "/"
 
     project = {'attributes': {'name': project_name}}
 
     s = Mock(spec=session.Session)
-    recurse = False
 
-    for (parent_path, parent, folders, files, revisions) in contents.walk(s, project):
+    for (parent, folders, files) in contents.walk(s, project):
         assert_equal(parent, project)
 
         for folder in folders:


### PR DESCRIPTION
We don’t save any time by returning breadcrumbs and head_revisions.
User can make these calls themselves, and save time in traversal if
they don’t need them.